### PR TITLE
fix: Add jdbc:mysql:// protocol prefix to database URL

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@ provider:
   memorySize: 512
   environment:
     # Database Configuration
-    DB_URL: ${env:DB_URL}/${env:DB_NAME}
+    DB_URL: jdbc:mysql://${env:DB_URL}/${env:DB_NAME}
     DB_USERNAME: ${env:DB_USERNAME}
     DB_PASSWORD: ${env:DB_PASSWORD}
     # AWS Configuration


### PR DESCRIPTION
- Add jdbc:mysql:// prefix to DB_URL construction in serverless.yml
- Fixes 'Cannot create JDBC driver' error for MySQL connection
- Ensures proper JDBC URL format: jdbc:mysql://hostname:port/database

- Before: teckiz-prod-sql8.czn2kivgj6u7.ap-south-1.rds.amazonaws.com/teckiz_test
- After:  jdbc:mysql://teckiz-prod-sql8.czn2kivgj6u7.ap-south-1.rds.amazonaws.com/teckiz_test

- Benefits:
  - Proper JDBC URL format for MySQL driver
  - Resolves JDBC driver creation error
  - Ensures database connection can be established
  - Follows standard JDBC URL conventions