### PR TITLE
fix: add all required environment variables for CI/CD deployment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -211,20 +211,25 @@ jobs:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
           # Database
           DB_URL: ${{ secrets.DB_URL }}
-          DB_USER: ${{ secrets.DB_USERNAME }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           DB_NAME: ${{ secrets.DB_NAME }}
           # SQS
           SQS_QUEUE_ARN: ${{ secrets.SQS_QUEUE_ARN }}
           SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
-          # VPC Configuration (add these secrets to GitHub!)
+          # VPC Configuration
           VPC_ID: ${{ secrets.VPC_ID }}
           VPC_CIDR: ${{ secrets.VPC_CIDR }}
           VPC_SECURITY_GROUP_ID: ${{ secrets.VPC_SECURITY_GROUP_ID }}
           VPC_SUBNET_ID_1: ${{ secrets.VPC_SUBNET_ID_1 }}
           VPC_SUBNET_ID_2: ${{ secrets.VPC_SUBNET_ID_2 }}
+          # MySQL Configuration
           MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
-          MYSQL_PORT: ${{ secrets.MYSQL_PORT }}
+          MYSQL_PORT: "3306"
+          MYSQL_DATABASE: ${{ secrets.DB_NAME }}
+          MYSQL_SSL_MODE: "REQUIRED"
+          MYSQL_CONNECTION_TIMEOUT: "30000"
+          MYSQL_SOCKET_TIMEOUT: "30000"
         run: |
           echo "🔐 Logging into Serverless Framework..."
           if [ -n "$SERVERLESS_ACCESS_KEY" ]; then

--- a/README.md
+++ b/README.md
@@ -841,34 +841,35 @@ AWS_ACCESS_KEY_ID              # Your AWS access key
 AWS_SECRET_ACCESS_KEY          # Your AWS secret key  
 AWS_REGION                     # ap-south-1
 SERVERLESS_ACCESS_KEY          # Serverless Framework key
-DEPLOYMENT_BUCKET_NAME         # teckiz-deployment-bucket
+DEPLOYMENT_BUCKET_NAME         # teckiz-deployment-bucket (used as SERVERLESS_DEPLOYMENT_BUCKET)
 S3_BUCKET_NAME                 # index-journal-files
-DB_URL                         # jdbc:mysql://...
-DB_USERNAME                    # teckiz (maps to DB_USER in serverless.yml)
+DB_URL                         # jdbc:mysql://teckiz-prod-sql8...
+DB_USERNAME                    # teckiz
 DB_PASSWORD                    # Your DB password
 DB_NAME                        # teckiz_test
-SQS_QUEUE_ARN                  # arn:aws:sqs:ap-south-1:...
-SQS_QUEUE_URL                  # https://sqs.ap-south-1...
+SQS_QUEUE_ARN                  # arn:aws:sqs:ap-south-1:518624980012:journal-integration-queue
+SQS_QUEUE_URL                  # https://sqs.ap-south-1.amazonaws.com/518624980012/...
 SONAR_TOKEN                    # SonarCloud token
 SONAR_PROJECT_KEY              # SonarCloud project key
 SONAR_ORGANIZATION             # SonarCloud organization
 ```
 
-#### ⚠️ Missing - Need to Add These
+#### ⚠️ Missing - Need to Add These 6 Secrets
 
 **VPC Configuration** (from your `environments/env.production` file):
 
-```
-VPC_ID=vpc-09dca361
-VPC_CIDR=172.31.0.0/16
-VPC_SECURITY_GROUP_ID=sg-06a9ab999bcbf0681
-VPC_SUBNET_ID_1=subnet-81e887e9
-VPC_SUBNET_ID_2=subnet-3044987c
-MYSQL_HOST=teckiz-prod-sql8.czn2kivgj6u7.ap-south-1.rds.amazonaws.com
-MYSQL_PORT=3306
-```
+Go to: `Settings → Secrets and variables → Actions → New repository secret`
 
-**Add these 7 secrets to GitHub** to enable CI/CD deployment!
+| Secret Name | Value |
+|-------------|-------|
+| `VPC_ID` | `vpc-09dca361` |
+| `VPC_CIDR` | `172.31.0.0/16` |
+| `VPC_SECURITY_GROUP_ID` | `sg-06a9ab999bcbf0681` |
+| `VPC_SUBNET_ID_1` | `subnet-81e887e9` |
+| `VPC_SUBNET_ID_2` | `subnet-3044987c` |
+| `MYSQL_HOST` | `teckiz-prod-sql8.czn2kivgj6u7.ap-south-1.rds.amazonaws.com` |
+
+**Note**: `MYSQL_PORT` is hardcoded to `3306` in the workflow (standard MySQL port)
 
 ---
 


### PR DESCRIPTION
- Fix DB_USER → DB_USERNAME to match serverless.yml expectations
- Add missing MySQL configuration variables (MYSQL_DATABASE, MYSQL_SSL_MODE, etc.)
- Set MYSQL_PORT to 3306 (no secret needed - standard port)
- Set MYSQL_DATABASE from DB_NAME secret
- Document exact 6 missing secrets needed for VPC deployment
- Update README with current vs. missing secrets status

Environment variable mapping:
- DB_USERNAME → from GitHub secret DB_USERNAME
- MYSQL_DATABASE → from GitHub secret DB_NAME
- MYSQL_PORT → hardcoded to 3306
- MYSQL_SSL_MODE → hardcoded to REQUIRED
- MYSQL_CONNECTION_TIMEOUT → hardcoded to 30000
- MYSQL_SOCKET_TIMEOUT → hardcoded to 30000