### PR TITLE
fix: auto-extract MYSQL_HOST from DB_URL in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -224,13 +224,16 @@ jobs:
           VPC_SUBNET_ID_1: ${{ secrets.VPC_SUBNET_ID_1 }}
           VPC_SUBNET_ID_2: ${{ secrets.VPC_SUBNET_ID_2 }}
           # MySQL Configuration
-          MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
           MYSQL_PORT: "3306"
           MYSQL_DATABASE: ${{ secrets.DB_NAME }}
           MYSQL_SSL_MODE: "REQUIRED"
           MYSQL_CONNECTION_TIMEOUT: "30000"
           MYSQL_SOCKET_TIMEOUT: "30000"
         run: |
+          # Extract MYSQL_HOST from DB_URL (jdbc:mysql://HOST:PORT/DATABASE)
+          export MYSQL_HOST=$(echo "$DB_URL" | sed -n 's#.*://\([^:]*\):.*#\1#p')
+          echo "📝 Extracted MYSQL_HOST: $MYSQL_HOST"
+          
           echo "🔐 Logging into Serverless Framework..."
           if [ -n "$SERVERLESS_ACCESS_KEY" ]; then
             echo "$SERVERLESS_ACCESS_KEY" | serverless login --key

--- a/README.md
+++ b/README.md
@@ -854,22 +854,23 @@ SONAR_PROJECT_KEY              # SonarCloud project key
 SONAR_ORGANIZATION             # SonarCloud organization
 ```
 
-#### ⚠️ Missing - Need to Add These 6 Secrets
+#### ✅ All Secrets Now Configured!
 
-**VPC Configuration** (from your `environments/env.production` file):
+**VPC Configuration** (recently added):
 
-Go to: `Settings → Secrets and variables → Actions → New repository secret`
+| Secret Name | Value | Status |
+|-------------|-------|--------|
+| `VPC_ID` | `vpc-09dca361` | ✅ Added |
+| `VPC_CIDR` | `172.31.0.0/16` | ✅ Added |
+| `VPC_SECURITY_GROUP_ID` | `sg-06a9ab999bcbf0681` | ✅ Added |
+| `VPC_SUBNET_ID_1` | `subnet-81e887e9` | ✅ Added |
+| `VPC_SUBNET_ID_2` | `subnet-3044987c` | ✅ Added |
 
-| Secret Name | Value |
-|-------------|-------|
-| `VPC_ID` | `vpc-09dca361` |
-| `VPC_CIDR` | `172.31.0.0/16` |
-| `VPC_SECURITY_GROUP_ID` | `sg-06a9ab999bcbf0681` |
-| `VPC_SUBNET_ID_1` | `subnet-81e887e9` |
-| `VPC_SUBNET_ID_2` | `subnet-3044987c` |
-| `MYSQL_HOST` | `teckiz-prod-sql8.czn2kivgj6u7.ap-south-1.rds.amazonaws.com` |
-
-**Note**: `MYSQL_PORT` is hardcoded to `3306` in the workflow (standard MySQL port)
+**Notes**: 
+- `MYSQL_HOST` is **automatically extracted** from `DB_URL` in the workflow
+- `MYSQL_PORT` is hardcoded to `3306` (standard MySQL port)
+- `MYSQL_DATABASE` uses the `DB_NAME` secret
+- `MYSQL_SSL_MODE`, timeouts are hardcoded to production values
 
 ---
 


### PR DESCRIPTION
- Extract MYSQL_HOST from DB_URL using sed (no separate secret needed)
- All VPC secrets now configured in GitHub
- Update README to reflect all secrets are now present
- CI/CD workflow now has all required environment variables

Environment variable resolution:
✅ DB_USERNAME → from secret DB_USERNAME
✅ MYSQL_HOST → auto-extracted from DB_URL (jdbc:mysql://HOST:PORT/DB) ✅ MYSQL_PORT → hardcoded to 3306
✅ MYSQL_DATABASE → from secret DB_NAME
✅ All VPC variables → from GitHub secrets

Ready for CI/CD deployment!