### PR TITLE
Fix: Handle duplicate records in repository queries

### DIFF
--- a/src/main/java/com/teckiz/journalindex/repository/IndexJournalArticleRepository.java
+++ b/src/main/java/com/teckiz/journalindex/repository/IndexJournalArticleRepository.java
@@ -38,8 +38,15 @@ public interface IndexJournalArticleRepository extends JpaRepository<IndexJourna
     
     /**
      * Find articles by publisher record ID
+     * Returns all matches (handles duplicates)
      */
-    Optional<IndexJournalArticle> findByPublisherRecordId(String publisherRecordId);
+    @Query("SELECT a FROM IndexJournalArticle a WHERE a.publisherRecordId = :publisherRecordId ORDER BY a.id ASC")
+    List<IndexJournalArticle> findAllByPublisherRecordId(@Param("publisherRecordId") String publisherRecordId);
+    
+    default Optional<IndexJournalArticle> findByPublisherRecordId(String publisherRecordId) {
+        List<IndexJournalArticle> results = findAllByPublisherRecordId(publisherRecordId);
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
     
     /**
      * Find articles by article type
@@ -110,6 +117,13 @@ public interface IndexJournalArticleRepository extends JpaRepository<IndexJourna
     
     /**
      * Find article by page URL
+     * Returns first result if multiple exist (handles duplicates)
      */
-    Optional<IndexJournalArticle> findByPageURL(String pageURL);
+    @Query("SELECT a FROM IndexJournalArticle a WHERE a.pageURL = :pageURL ORDER BY a.id ASC")
+    List<IndexJournalArticle> findAllByPageURL(@Param("pageURL") String pageURL);
+    
+    default Optional<IndexJournalArticle> findByPageURL(String pageURL) {
+        List<IndexJournalArticle> results = findAllByPageURL(pageURL);
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
 }

--- a/src/main/java/com/teckiz/journalindex/repository/IndexJournalVolumeRepository.java
+++ b/src/main/java/com/teckiz/journalindex/repository/IndexJournalVolumeRepository.java
@@ -87,7 +87,14 @@ public interface IndexJournalVolumeRepository extends JpaRepository<IndexJournal
     boolean existsByPublisherRecordId(String publisherRecordId);
     
     /**
-     * Find volume by journal ID and volume number
+     * Find volumes by journal ID and volume number
+     * Returns all matches (handles duplicates)
      */
-    Optional<IndexJournalVolume> findByIndexJournalIdAndVolumeNumber(Long journalId, String volumeNumber);
+    @Query("SELECT v FROM IndexJournalVolume v WHERE v.indexJournal.id = :journalId AND v.volumeNumber = :volumeNumber ORDER BY v.id ASC")
+    List<IndexJournalVolume> findAllByIndexJournalIdAndVolumeNumber(@Param("journalId") Long journalId, @Param("volumeNumber") String volumeNumber);
+    
+    default Optional<IndexJournalVolume> findByIndexJournalIdAndVolumeNumber(Long journalId, String volumeNumber) {
+        List<IndexJournalVolume> results = findAllByIndexJournalIdAndVolumeNumber(journalId, volumeNumber);
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
 }


### PR DESCRIPTION
- Update IndexJournalArticleRepository to handle multiple results for findByPageURL and findByPublisherRecordId
- Update IndexJournalVolumeRepository to handle multiple results for findByIndexJournalIdAndVolumeNumber
- Add default methods that return first result when duplicates exist instead of throwing IncorrectResultSizeDataAccessException
- Queries now return List and default methods extract first result with consistent ordering by ID

This prevents exceptions when the database contains duplicate records for fields that should be unique but aren't enforced at the database level.