### PR TITLE
Optimize Lambda configuration for minimal resource usage

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -7,8 +7,8 @@ provider:
   runtime: java21
   region: ${opt:region, 'ap-south-1'}
   stage: ${opt:stage, 'dev'}
-  timeout: 300
-  memorySize: 1024
+  timeout: 300  # 5 minutes (function-level overrides this)
+  memorySize: 512  # 512MB minimum for Java runtime
   deploymentBucket:
     name: ${env:SERVERLESS_DEPLOYMENT_BUCKET}
   vpc:
@@ -39,7 +39,7 @@ provider:
     # Function Configuration
     FUNCTION_TYPE: processor
     LOG_LEVEL: INFO
-    JAVA_TOOL_OPTIONS: "-XX:MaxHeapSize=768m -XX:+UseG1GC"
+    JAVA_TOOL_OPTIONS: "-XX:MaxHeapSize=384m -XX:+UseG1GC"
   iam:
     role:
       statements:
@@ -81,8 +81,8 @@ functions:
     handler: com.teckiz.journalindex.LambdaHandler
     name: ${self:service}-${self:provider.stage}-processor
     description: "Processes article JSON messages from SQS and saves directly to database"
-    timeout: 300
-    memorySize: 1024
+    timeout: 300  # 5 minutes
+    memorySize: 512  # Minimum memory for Java runtime
     snapStart: true  # Enable SnapStart for near-instant cold starts
     vpc:
       securityGroupIds:


### PR DESCRIPTION
- Reduce memory from 1024MB to 512MB (minimum for Java runtime)
- Reduce Java heap size from 768MB to 384MB (fits within 512MB with ~128MB overhead)
- Keep timeout at 5 minutes (300 seconds)
- Add comments for clarity

This configuration optimizes cost while maintaining functionality for the article processing Lambda function.