### PR TITLE
Switch to Java 17 and optimize Lambda configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - integration-work-flow
 
 env:
-  JAVA_VERSION: '21'
+  JAVA_VERSION: '17'
   MAVEN_VERSION: '3.9.9'
 
 jobs:
@@ -32,7 +32,12 @@ jobs:
           cache: 'maven'
 
       - name: Check code formatting with Maven
-        run: mvn spotless:check || echo "No spotless plugin configured"
+        run: |
+          if grep -q "spotless-maven-plugin" pom.xml 2>/dev/null; then
+            mvn spotless:check
+          else
+            echo "ℹ️ Spotless plugin not configured, skipping code format check"
+          fi
         continue-on-error: true
 
       - name: Run Maven validate

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  JAVA_VERSION: '21'
+  JAVA_VERSION: '17'
   MAVEN_VERSION: '3.9.9'
 
 jobs:
@@ -29,7 +29,12 @@ jobs:
           cache: 'maven'
 
       - name: Check code formatting
-        run: mvn spotless:check || echo "No spotless plugin configured"
+        run: |
+          if grep -q "spotless-maven-plugin" pom.xml 2>/dev/null; then
+            mvn spotless:check
+          else
+            echo "ℹ️ Spotless plugin not configured, skipping code format check"
+          fi
         continue-on-error: true
 
       - name: Run Maven validate

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>Fanout Lambda service for OAI harvesting and MySQL storage</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -284,8 +284,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,11 +4,11 @@ frameworkVersion: '4'
 
 provider:
   name: aws
-  runtime: java21
+  runtime: java17
   region: ${opt:region, 'ap-south-1'}
   stage: ${opt:stage, 'dev'}
   timeout: 300  # 5 minutes (function-level overrides this)
-  memorySize: 512  # 512MB minimum for Java runtime
+  memorySize: 768  # 768MB minimum for Spring + Hibernate initialization
   deploymentBucket:
     name: ${env:SERVERLESS_DEPLOYMENT_BUCKET}
   vpc:
@@ -39,7 +39,7 @@ provider:
     # Function Configuration
     FUNCTION_TYPE: processor
     LOG_LEVEL: INFO
-    JAVA_TOOL_OPTIONS: "-XX:MaxHeapSize=384m -XX:+UseG1GC"
+    JAVA_TOOL_OPTIONS: "-XX:MaxHeapSize=512m -XX:+UseG1GC"
   iam:
     role:
       statements:
@@ -82,7 +82,7 @@ functions:
     name: ${self:service}-${self:provider.stage}-processor
     description: "Processes article JSON messages from SQS and saves directly to database"
     timeout: 300  # 5 minutes
-    memorySize: 512  # Minimum memory for Java runtime
+    memorySize: 768  # 768MB minimum for Spring + Hibernate initialization
     snapStart: true  # Enable SnapStart for near-instant cold starts
     vpc:
       securityGroupIds:


### PR DESCRIPTION
- Change runtime from Java 21 to Java 17 for better AWS Lambda compatibility
- Update Maven configuration to compile with Java 17
- Update GitHub Actions workflows to use Java 17 (build.yml, ci-cd.yml)
- Adjust Lambda memory from 512MB to 768MB to support Spring + Hibernate initialization
- Update Java heap size to 512MB (fits within 768MB with ~256MB overhead)
- Fix Spotless plugin check in workflows to prevent errors when plugin not configured

Java 17 is more stable and widely supported on AWS Lambda, which should resolve the Lambda initialization failures. The 768MB memory configuration provides sufficient resources for Spring context, Hibernate, and database connection pooling while remaining cost-effective.